### PR TITLE
Fix missing time in beresp.ttl statement.

### DIFF
--- a/doc/sphinx/tutorial/vcl.rst
+++ b/doc/sphinx/tutorial/vcl.rst
@@ -154,7 +154,7 @@ matches certain criteria:::
   sub vcl_fetch {
      if (req.url ~ "\.(png|gif|jpg)$") {
        unset beresp.http.set-cookie;
-       set beresp.ttl = 3600;
+       set beresp.ttl = 3600s;
     }
   }
 


### PR DESCRIPTION
I've fixed a small typo in the 2.1 VCL tutorial.
