### PR TITLE
Update doc/sphinx/tutorial/compression.rst

### DIFF
--- a/doc/sphinx/tutorial/compression.rst
+++ b/doc/sphinx/tutorial/compression.rst
@@ -1,7 +1,7 @@
 .. _tutorial-compression:
 
 Compression
-~~~~~~~~~~~
+-----------
 
 New in Varnish 3.0 was native support for compression, using gzip
 encoding. *Before* 3.0, Varnish would never compress objects. 


### PR DESCRIPTION
This should fix the nesting (the subsections on compression appear
in the main TOC, at the same level as the compression heading itself).
