### PR TITLE
Add c_purge performance counter to track object purges.

### DIFF
--- a/bin/varnishd/cache_hash.c
+++ b/bin/varnishd/cache_hash.c
@@ -573,6 +573,7 @@ HSH_Purge(const struct sess *sp, struct objhead *oh, double ttl, double grace)
 		o->exp.ttl = ttl;
 		o->exp.grace = grace;
 		EXP_Rearm(o);
+		VSC_C_main->c_purge++;
 		(void)HSH_Deref(sp->wrk, NULL, &o);
 	}
 	WS_Release(sp->wrk->ws, 0);

--- a/include/vsc_fields.h
+++ b/include/vsc_fields.h
@@ -99,6 +99,7 @@ VSC_F(n_backend,		uint64_t, 0, 'i', "N backends", "")
 VSC_F(n_expired,		uint64_t, 0, 'i', "N expired objects", "")
 VSC_F(n_lru_nuked,		uint64_t, 0, 'i', "N LRU nuked objects", "")
 VSC_F(n_lru_moved,		uint64_t, 0, 'i', "N LRU moved objects", "")
+VSC_F(c_purge,		    uint64_t, 0, 'a', "N purged objects", "")
 
 VSC_F(losthdr,		uint64_t, 0, 'a', "HTTP header overflows", "")
 
@@ -217,4 +218,3 @@ VSC_F(vcls,			uint64_t, 0, 'i', "VCL references", "")
 VSC_F(happy,		uint64_t, 0, 'b', "Happy health probes", "")
 
 #endif
-


### PR DESCRIPTION
This performance counter tracks purges of individual objects, which is
typically done using the 'purge;' command in VCL.  The counter tracks
actual objects purged, and not purge requests; this means that if
'purge;' is called on an object not in the cache it will not increment
the counter.
