### PR TITLE
Added `python-docutils` to the required package list (Debian / Ubuntu)

### DIFF
--- a/doc/sphinx/installation/install.rst
+++ b/doc/sphinx/installation/install.rst
@@ -95,6 +95,7 @@ installed. On a Debian or Ubuntu system these are:
 * groff-base
 * libpcre3-dev
 * pkg-config
+* python-docutils
 
 Build dependencies on Red Hat / CentOS
 --------------------------------------


### PR DESCRIPTION
When following the build from source guide on Ubuntu 12.04 LTS I ran into the following error while running `make`:

> You need rst2man installed to make dist

Installing `python-docutils` fixed the problem.

I think `python-docutils` should be added to the required list of packages for Debian / Ubuntu.
