### PR TITLE
Documentation: Minor addition to the reference

### DIFF
--- a/doc/sphinx/reference/varnish-cli.rst
+++ b/doc/sphinx/reference/varnish-cli.rst
@@ -80,8 +80,11 @@ backend.list
       Lists the defined backends including health state.
 
 backend.set_health matcher state
-      Sets the health state on a specific backend. This is useful if
-      you want to take a certain backend out of circulation.
+      Sets the health state on a specific backend, overriding the state
+      determined by a probe.  This is useful if you want to take a
+      certain backend out of circulation.
+
+      *state* can be 'auto', 'sick' or 'healthy'.
 
 ban   *field operator argument* [&& field operator argument [...]]
       Immediately invalidate all documents matching the ban


### PR DESCRIPTION
A result of the following conversation on IRC;

13:20:33 < tv> what options does backend.set_health take as its state parameter?
13:21:38 < tv> I've set a backend as sick, done some maintenance, then I set it back to healthy ... but all the other backends has state 'probe' ... which I got a feeling is what I want; but probe is an invalid parameter
13:21:52 < tv> I take it as I've overridden the probe state with my own, now
13:22:22 @Mithrandir probe is called auto, I think
13:22:39 < tv> you are right, thanks :)
13:23:03  \* tv looked up in https://www.varnish-cache.org/docs/trunk/reference/varnish-cli.html, but didn't find it.
