### PR TITLE
Add travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+script: 'make check'
+before_install:
+  - sudo apt-get install python-docutils
+  - ./autogen.sh
+  - ./configure


### PR DESCRIPTION
This file adds support for running tests on Travis CI (https://travis-ci.org). The build results for this commit can be found here: https://travis-ci.org/jbussdieker/Varnish-Cache/builds/9781384
