### PR TITLE
varnishncsa: Correct description of %D format

### DIFF
--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -101,7 +101,7 @@ static struct logline {
 	char *df_u;			/* %u, Remote user */
 	char *df_ttfb;			/* Time to first byte */
 	double df_D;			/* %D, time taken to serve the request,
-					   in microseconds, also used for %T */
+					   in seconds, also used for %T */
 	const char *df_hitmiss;		/* Whether this is a hit or miss */
 	const char *df_handling;	/* How the request was handled
 					   (hit/miss/pass/pipe) */

--- a/doc/sphinx/reference/varnishncsa.rst
+++ b/doc/sphinx/reference/varnishncsa.rst
@@ -56,7 +56,8 @@ The following options are available:
    	         bytes are sent.
 
 	      %D
-	         Time taken to serve the request, in microseconds.
+	         Time taken to serve the request, in seconds with
+             microsecond fractional part.
 
 	      %H 
 	         The request protocol. Defaults to HTTP/1.0 if not


### PR DESCRIPTION
The %D format option to varnishncsa is described as microseconds. This is incorrect: it is actually seconds with a microsecond fractional part.

This commit updates the documentation and the comment in varnishncsa.c
