### PR TITLE
Available commands in varnishtest script

### DIFF
--- a/doc/sphinx/reference/varnishtest.rst
+++ b/doc/sphinx/reference/varnishtest.rst
@@ -118,7 +118,7 @@ AVAILABLE COMMANDS
 
 **server**
 
- Creates mock of a server that can accept requests from Varnish and send responses. Accepted parameters:
+Creates mock of a server that can accept requests from Varnish and send responses. Accepted parameters:
  
 -wait
  (?)
@@ -131,7 +131,7 @@ AVAILABLE COMMANDS
 
 **client**
 
- Creates a client instance that sends requests to Varnish and receives responses. Accepted parameters:
+Creates a client instance that sends requests to Varnish and receives responses. Accepted parameters:
 
 -wait
  waits for commands to complete
@@ -146,7 +146,7 @@ AVAILABLE COMMANDS
  
 **varnish**
 
- Starts Varnish instance. Accepted arguments:
+Starts Varnish instance. Accepted arguments:
 
 -arg
  pass additional arguments to varnishd
@@ -173,43 +173,43 @@ AVAILABLE COMMANDS
 -expect
  set up a test for asserting variables against expected results. Syntax: "-expect <var> <comparison> <const>"
  
- See tests supplied with Varnish distribution for usage examples for all these directives.
+See tests supplied with Varnish distribution for usage examples for all these directives.
 
 **delay**
 
- Sleeps for specified number of seconds. Can accept floating point numbers. 
+Sleeps for specified number of seconds. Can accept floating point numbers. 
  
- Usage: ``delay 0.1``
+Usage: ``delay 0.1``
 
 **varnishtest**
 
- Accepts a string as an only argument. This being a test name that is being output 
- into the log. By default, test name is not shown, unless it fails.
+Accepts a string as an only argument. This being a test name that is being output 
+into the log. By default, test name is not shown, unless it fails.
 
 **shell**
 
- Executes a shell command. Accepts one argument as a string, and runs the command as is. 
+Executes a shell command. Accepts one argument as a string, and runs the command as is. 
  
- Usage: ``shell "date"``
+Usage: ``shell "date"``
 
 **sema**
 
- (todo)
+(todo)
  
- Semaphores mostly used to synchronize clients and servers "around"
- varnish, so that the server will not send something particular
- until the client tells it to, but it can also be used synchronize
- multiple clients or servers running in parallel.
+Semaphores mostly used to synchronize clients and servers "around"
+varnish, so that the server will not send something particular
+until the client tells it to, but it can also be used synchronize
+multiple clients or servers running in parallel.
 
 **random**
 
- Initializes random generator
+Initializes random generator
 
 **feature**
 
- Checks for features to be present in the test environment. If feature is not present, test is skipped. 
+Checks for features to be present in the test environment. If feature is not present, test is skipped. 
  
- Usage: ``feature 64bit SO_RCVTIMEO_WORKS``
+Usage: ``feature 64bit SO_RCVTIMEO_WORKS``
 
 Possible checks:
 

--- a/doc/sphinx/reference/varnishtest.rst
+++ b/doc/sphinx/reference/varnishtest.rst
@@ -9,7 +9,7 @@ Test program for Varnish
 :Author: Stig Sandbeck Mathisen
 :Author: Kristian Lyngstøl
 :Date:   2011-11-15
-:Version: 1.1
+:Version: 1.2
 :Manual section: 1
 
 
@@ -112,6 +112,117 @@ When run, the above script will simulate a server (s1) that expects two
 different requests. It will start a varnish server (v1) and add the backend
 definition to the VCL specified (-vcl+backend). Finally it starts the
 c1-client, which is a single client sending two requests.
+
+AVAILABLE COMMANDS
+==================
+
+**server**
+
+ Creates mock of a server that can accept requests from Varnish and send responses. Accepted parameters:
+ 
+-wait
+ (?)
+-repeat
+ (?)
+-listen
+ specifies address and port to listen on (e.g. "127.0.0.1:80")
+-start
+ starts the server
+
+**client**
+
+ Creates a client instance that sends requests to Varnish and receives responses. Accepted parameters:
+
+-wait
+ waits for commands to complete
+-connect
+ specify where to connect to (e.g. "-connect ${s1_sock}").
+-repeat
+ (?)
+-start
+ start the client, and continue without waiting for completion
+-run
+ equivalent to -start then -wait
+ 
+**varnish**
+
+ Starts Varnish instance. Accepted arguments:
+
+-arg
+ pass additional arguments to varnishd
+-cli
+ execute a command in CLI of running instance
+-cliok
+ (?) execute a command and expect it return OK status
+-clierr
+ (?) execute a command and expect it to error with given status (e.g. "-clierr 300 panic.clear")
+-vcl+backend
+ specify VCL for the instance, and automatically inject a backend into the VCL
+-errvcl
+ (?) tests that invalid VCL results in an error. Replaces -badvcl.
+-vcl
+ specify VCL for the instance
+-stop
+ stop the instance
+-wait-stopped
+ (?) wait for the server to stop?
+-wait-running
+ (?) wait for the server to start?
+-wait
+ (?)
+-expect
+ set up a test for asserting variables against expected results. Syntax: "-expect <var> <comparison> <const>"
+ 
+ See tests supplied with Varnish distribution for usage examples for all these directives.
+
+**delay**
+
+ Sleeps for specified number of seconds. Can accept floating point numbers. 
+ 
+ Usage: ``delay 0.1``
+
+**varnishtest**
+
+ Accepts a string as an only argument. This being a test name that is being output 
+ into the log. By default, test name is not shown, unless it fails.
+
+**shell**
+
+ Executes a shell command. Accepts one argument as a string, and runs the command as is. 
+ 
+ Usage: ``shell "date"``
+
+**sema**
+
+ (todo)
+ 
+ Semaphores mostly used to synchronize clients and servers "around"
+ varnish, so that the server will not send something particular
+ until the client tells it to, but it can also be used synchronize
+ multiple clients or servers running in parallel.
+
+**random**
+
+ Initializes random generator
+
+**feature**
+
+ Checks for features to be present in the test environment. If feature is not present, test is skipped. 
+ 
+ Usage: ``feature 64bit SO_RCVTIMEO_WORKS``
+
+Possible checks:
+
+SO_RCVTIMEO_WORKS
+ runs the test only if SO_RCVTIMEO option works in the environment
+64bit
+ runs the test only if environment is 64 bit
+!OSX
+ skips the test if ran on OSX
+topbuild
+ (?)
+logexpect
+ This allows checking order and contents of VSL records in varnishtest.
 
 SEE ALSO
 ========


### PR DESCRIPTION
Added available commands section to varnishtest reference. Still have some issues with formatting, like with "-vcl+backend" in the command list, and in the "feature" command description. Can someone help with that?

Also, need help with defining all question marks that I don't understand well.
