### PR TITLE
Error on the example for Backends and vhosts

### DIFF
--- a/doc/sphinx/users-guide/vcl-backends.rst
+++ b/doc/sphinx/users-guide/vcl-backends.rst
@@ -100,7 +100,7 @@ this example this is intentional but you might want it to be a bit
 more tight, maybe relying on the ``==`` operator in stead, like this:::
 
     sub vcl_recv {
-        if (req.http.host == "foo.com" or req.http.host == "www.foo.com") {
+        if (req.http.host == "foo.com" || req.http.host == "www.foo.com") {
             set req.backend_hint = foo;
         }
     }


### PR DESCRIPTION
The example for 'Backends and virtual hosts' contains an error: It says 'or' instead of '||'.

This is the error you get:

```
Message from VCC-compiler:
Expected ')' got 'or'
(program line 69), at
('input' Line 79 Pos 43)
        if (req.http.host == "foo.com" or req.http.host == "www.foo.com") {
------------------------------------------##-------------------------------------

Running VCC-compiler failed, exit 1

VCL compilation failed
```
