### PR TITLE
regsuball() doesn't honor lookahead assertion on repeated strings

### DIFF
--- a/bin/varnishd/cache/cache_vrt_re.c
+++ b/bin/varnishd/cache/cache_vrt_re.c
@@ -90,7 +90,7 @@ VRT_regsub(const struct vrt_ctx *ctx, int all, const char *str, void *re,
 	txt res;
 	char *b0;
 	const char *s;
-	unsigned u, x;
+	unsigned u, x, offset = 0;
 	int options = 0;
 	size_t len;
 
@@ -103,7 +103,7 @@ VRT_regsub(const struct vrt_ctx *ctx, int all, const char *str, void *re,
 	t = re;
 	memset(ovector, 0, sizeof(ovector));
 	len = strlen(str);
-	i = VRE_exec(t, str, len, 0, options, ovector, 30,
+	i = VRE_exec(t, str, len, offset, options, ovector, 30,
 	    &cache_param->vre_limits);
 
 	/* If it didn't match, we can return the original string */
@@ -120,7 +120,7 @@ VRT_regsub(const struct vrt_ctx *ctx, int all, const char *str, void *re,
 
 	do {
 		/* Copy prefix to match */
-		Tadd(&res, str, ovector[0]);
+		Tadd(&res, str+offset, ovector[0]-offset);
 		for (s = sub ; *s != '\0'; s++ ) {
 			if (*s != '\\' || s[1] == '\0') {
 				if (res.b < res.e)
@@ -138,13 +138,12 @@ VRT_regsub(const struct vrt_ctx *ctx, int all, const char *str, void *re,
 					*res.b++ = *s;
 			}
 		}
-		str += ovector[1];
-		len -= ovector[1];
+		offset = ovector[1];
 		if (!all)
 			break;
 		memset(&ovector, 0, sizeof(ovector));
 		options |= VRE_NOTEMPTY;
-		i = VRE_exec(t, str, len, 0, options, ovector, 30,
+		i = VRE_exec(t, str, len, offset, options, ovector, 30,
 		    &cache_param->vre_limits);
 		if (i < VRE_ERROR_NOMATCH ) {
 			WS_Release(ctx->ws, 0);
@@ -155,7 +154,7 @@ VRT_regsub(const struct vrt_ctx *ctx, int all, const char *str, void *re,
 	} while (i != VRE_ERROR_NOMATCH);
 
 	/* Copy suffix to match */
-	Tadd(&res, str, len+1);
+	Tadd(&res, str+offset, len-offset);
 	if (res.b >= res.e) {
 		WS_Release(ctx->ws, 0);
 		return (str);

--- a/bin/varnishtest/tests/r01557.vtc
+++ b/bin/varnishtest/tests/r01557.vtc
@@ -1,0 +1,19 @@
+varnishtest "#1557 regsuball() doesn't honor lookahead assertion on repeated strings"
+
+server s1 {
+	rxreq 
+	txresp 
+} -start
+
+varnish v1 -vcl+backend { 
+	sub vcl_backend_response {
+		set beresp.http.foo = regsuball(bereq.url, "(?<=[&\?])(id|name|age)=[^&]+(?:&|$)", "");
+	}
+} -start 
+
+client c1 {
+	txreq -url "/?id=23&name=foo&age=42"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.foo == "/?"
+} -run


### PR DESCRIPTION
Fixes: #1557
