### PR TITLE
Move so structures members around for tighter packing

### DIFF
--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -116,9 +116,9 @@ struct ban {
 VTAILQ_HEAD(banhead_s,ban);
 
 struct ban_test {
+	uint8_t			oper;
 	uint8_t			arg1;
 	const char		*arg1_spec;
-	uint8_t			oper;
 	const char		*arg2;
 	const void		*arg2_spec;
 };

--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -43,12 +43,12 @@
 struct vef_priv {
 	unsigned		magic;
 #define VEF_MAGIC		0xf104b51f
+	int			error;
+	ssize_t			tot;
+
 	struct vgz		*vgz;
 
 	struct vep_state	*vep;
-
-	ssize_t			tot;
-	int			error;
 
 	char			*ibuf;
 	char			*ibuf_i;

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -101,12 +101,12 @@ struct format {
 	unsigned		magic;
 #define FORMAT_MAGIC		0xC3119CDA
 
+	char			time_type;
 	VTAILQ_ENTRY(format)	list;
 	format_f		*func;
 	struct fragment		*frag;
 	char			*string;
 	const char *const	*strptr;
-	char			time_type;
 	char			*time_fmt;
 };
 

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -53,8 +53,8 @@ struct client {
 
 	unsigned		repeat;
 
-	pthread_t		tp;
 	unsigned		running;
+	pthread_t		tp;
 };
 
 static VTAILQ_HEAD(, client)	clients =

--- a/lib/libvarnishapi/vsl_cursor.c
+++ b/lib/libvarnishapi/vsl_cursor.c
@@ -287,13 +287,14 @@ struct vslc_file {
 	unsigned			magic;
 #define VSLC_FILE_MAGIC			0x1D65FFEF
 
-	struct VSL_cursor		cursor;
-
 	int				error;
 	int				fd;
 	int				close_fd;
 	ssize_t				buflen;
 	uint32_t			*buf;
+
+	struct VSL_cursor		cursor;
+
 };
 
 static void

--- a/lib/libvgz/vgz.h
+++ b/lib/libvgz/vgz.h
@@ -85,11 +85,11 @@ struct internal_state;
 typedef struct z_stream_s {
     z_const Bytef *next_in;     /* next input byte */
     uInt     avail_in;  /* number of bytes available at next_in */
-    uLong    total_in;  /* total number of input bytes read so far */
-
-    Bytef    *next_out; /* next output byte should be put there */
     uInt     avail_out; /* remaining free space at next_out */
+
+    uLong    total_in;  /* total number of input bytes read so far */
     uLong    total_out; /* total number of bytes output so far */
+    Bytef    *next_out; /* next output byte should be put there */
 
     z_const char *msg;  /* last error message, NULL if no error */
     struct internal_state FAR *state; /* not visible by applications */


### PR DESCRIPTION
using pahole, we see that some structures could be smaller (fit in less cache lines). There few commits are a attempts to fix this by just shuffling member around, without screwing readability too much.