### PR TITLE
Ensure that syslog and network are part of the transaction

### DIFF
--- a/redhat/varnish.service
+++ b/redhat/varnish.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Varnish a high-perfomance HTTP accelerator
-After=syslog.target network.target
+After=network.target
+Requires=network.target
 
 [Service]
 


### PR DESCRIPTION
"After" only ensures ordering if the targets are part of the same transaction.  "Requires" only ensures that the targets are part of the same transaction, not ordering.  Thus, both are necessary to ensure reliable and deterministic startup.  Credit to @DavidStrauss at DrupalCon LA 2015 for spotting the issue!  He also suggests dropping syslog.target, as it's deprecated.  Quoth https://wiki.freedesktop.org/www/Software/systemd/syslog/:

"Newer systemd versions (v35+) do not support non-socket-activated syslog daemons anymore and we do no longer recommend people to order their units after syslog.target. That means that unless your syslog implementation is socket activatable many services will not be able to log to your syslog implementation and early boot messages are lost entirely to your implementation."
