### PR TITLE
Added -b (buffer size) parameter to varnishtest

### DIFF
--- a/bin/varnishtest/vtc_main.c
+++ b/bin/varnishtest/vtc_main.c
@@ -80,6 +80,7 @@ struct vtc_job {
 
 int iflg = 0;
 unsigned vtc_maxdur = 60;
+unsigned vtc_bufsiz = 512;
 
 static VTAILQ_HEAD(, vtc_tst) tst_head = VTAILQ_HEAD_INITIALIZER(tst_head);
 static struct vev_base *vb;
@@ -134,6 +135,7 @@ usage(void)
 	fprintf(stderr, FMT, "-q", "Quiet mode: report only failures");
 	fprintf(stderr, FMT, "-t duration", "Time tests out after this long");
 	fprintf(stderr, FMT, "-v", "Verbose mode: always report test log");
+	fprintf(stderr, FMT, "-b size", "Set internal buffer size in KB");
 	fprintf(stderr, "\n");
 	exit(1);
 }
@@ -234,7 +236,7 @@ start_test(void)
 	ALLOC_OBJ(jp, JOB_MAGIC);
 	AN(jp);
 
-	jp->bufsiz = 512*1024;		/* XXX */
+	jp->bufsiz = vtc_bufsiz*1024;
 
 	jp->buf = mmap(NULL, jp->bufsiz, PROT_READ|PROT_WRITE,
 	    MAP_ANON | MAP_SHARED, -1, 0);
@@ -490,6 +492,9 @@ main(int argc, char * const *argv)
 		case 'v':
 			if (vtc_verbosity < 2)
 				vtc_verbosity++;
+			break;
+		case 'b':
+			vtc_bufsiz = strtoul(optarg, NULL, 512);
 			break;
 		case 'W':
 			vtc_witness++;

--- a/doc/sphinx/reference/varnishtest.rst
+++ b/doc/sphinx/reference/varnishtest.rst
@@ -15,7 +15,7 @@ Test program for Varnish
 SYNOPSIS
 ========
 
-varnishtest [-iklLqv] [-n iter] [-D name=val] [-j jobs] [-t duration] file [file ...]
+varnishtest [-iklLqv] [-n iter] [-D name=val] [-j jobs] [-t duration] [-b size] file [file ...]
 
 DESCRIPTION
 ===========
@@ -49,6 +49,8 @@ The following options are available:
 -t duration      Time tests out after this long
 
 -v               Verbose mode: always report test log
+
+-b size          Set internal buffer size in KB
 
 -W               Enable the witness facility for locking
 


### PR DESCRIPTION
When implementing in VCL complex logic (not necessarely related with caching contents -e.g. access control, rate limiting, etc.-) varnishtest is a powerfull tool to automate testing. These type of tests sometimes are complex and they are not easy to split in smaller pieces.

In some extreme cases, the varnishlog buffer space allocated by varnishtest is not enough when testing complex VCL logic including a lot of logging. The size of that buffer is hard coded and it has been increased  in the past [1]. This simple commit allows selecting the size of that buffer in the command line.

[1] https://www.varnish-cache.org/trac/changeset/9511eefcdafea9a6c87f83a46d5e2b1d41c1c2c9