### PR TITLE
Fix left-shifting of negative value in libz

### DIFF
--- a/lib/libvgz/inflate.c
+++ b/lib/libvgz/inflate.c
@@ -1510,7 +1510,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL) return -(1L << 16);
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :


### PR DESCRIPTION
Doing a left-shift on a negative value is undefined. This throws an
error with clang 3.7.0. FreeBSD is importing clang 3.7.0 which uncovered
the error.

Credit: dim@FreeBSD.org
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=202958