### PR TITLE
Move structures members around for tighter packing

### DIFF
--- a/bin/varnishd/cache/cache_ban.c
+++ b/bin/varnishd/cache/cache_ban.c
@@ -50,9 +50,9 @@ static pthread_t ban_thread;
 static int ban_holds;
 
 struct ban_test {
+	uint8_t			oper;
 	uint8_t			arg1;
 	const char		*arg1_spec;
-	uint8_t			oper;
 	const char		*arg2;
 	const void		*arg2_spec;
 };

--- a/bin/varnishd/cache/cache_esi_fetch.c
+++ b/bin/varnishd/cache/cache_esi_fetch.c
@@ -44,12 +44,12 @@
 struct vef_priv {
 	unsigned		magic;
 #define VEF_MAGIC		0xf104b51f
+	int			error;
+	ssize_t			tot;
+
 	struct vgz		*vgz;
 
 	struct vep_state	*vep;
-
-	ssize_t			tot;
-	int			error;
 
 	char			*ibuf;
 	char			*ibuf_i;

--- a/bin/varnishncsa/varnishncsa.c
+++ b/bin/varnishncsa/varnishncsa.c
@@ -100,12 +100,12 @@ struct format {
 	unsigned		magic;
 #define FORMAT_MAGIC		0xC3119CDA
 
+	char			time_type;
 	VTAILQ_ENTRY(format)	list;
 	format_f		*func;
 	struct fragment		*frag;
 	char			*string;
 	const char *const	*strptr;
-	char			time_type;
 	char			*time_fmt;
 };
 

--- a/bin/varnishtest/vtc_client.c
+++ b/bin/varnishtest/vtc_client.c
@@ -53,8 +53,8 @@ struct client {
 
 	unsigned		repeat;
 
-	pthread_t		tp;
 	unsigned		running;
+	pthread_t		tp;
 };
 
 static VTAILQ_HEAD(, client)	clients =

--- a/lib/libvarnishapi/vsl_cursor.c
+++ b/lib/libvarnishapi/vsl_cursor.c
@@ -288,13 +288,14 @@ struct vslc_file {
 	unsigned			magic;
 #define VSLC_FILE_MAGIC			0x1D65FFEF
 
-	struct VSL_cursor		cursor;
-
 	int				error;
 	int				fd;
 	int				close_fd;
 	ssize_t				buflen;
 	uint32_t			*buf;
+
+	struct VSL_cursor		cursor;
+
 };
 
 static void


### PR DESCRIPTION
Same as #57 , rebased, and without touching zlib.