### PR TITLE
bind-before-connect parameter

### DIFF
--- a/bin/varnishd/cache/cache_backend_tcp.c
+++ b/bin/varnishd/cache/cache_backend_tcp.c
@@ -223,21 +223,23 @@ VBT_Open(const struct tcp_pool *tp, double tmo, const struct suckaddr **sa)
 {
 	int s;
 	int msec;
+	unsigned bindany;
 
 	CHECK_OBJ_NOTNULL(tp, TCP_POOL_MAGIC);
 
 	msec = (int)floor(tmo * 1000.0);
+	bindany = cache_param->connect_bindany;
 	if (cache_param->prefer_ipv6) {
 		*sa = tp->ip6;
-		s = VTCP_connect(tp->ip6, msec);
+		s = VTCP_connect(tp->ip6, msec, bindany);
 		if (s >= 0)
 			return(s);
 	}
 	*sa = tp->ip4;
-	s = VTCP_connect(tp->ip4, msec);
+	s = VTCP_connect(tp->ip4, msec, bindany);
 	if (s < 0 && !cache_param->prefer_ipv6) {
 		*sa = tp->ip6;
-		s = VTCP_connect(tp->ip6, msec);
+		s = VTCP_connect(tp->ip6, msec, bindany);
 	}
 	return(s);
 }

--- a/bin/varnishd/common/params.h
+++ b/bin/varnishd/common/params.h
@@ -168,6 +168,9 @@ struct params {
 	/* Default connection_timeout */
 	double			connect_timeout;
 
+	/* bind-before-connect strategy */
+	unsigned		connect_bindany;
+
 	/* CLI buffer size */
 	unsigned		cli_buffer;
 

--- a/bin/varnishd/mgt/mgt_cli.c
+++ b/bin/varnishd/mgt/mgt_cli.c
@@ -637,7 +637,7 @@ Marg_poker(const struct vev *e, int what)
 	AN(ma);
 
 	/* Try to connect asynchronously */
-	s = VTCP_connect(ma->sa, -1);
+	s = VTCP_connect(ma->sa, -1, 0);
 	if (s < 0)
 		return (0);
 

--- a/bin/varnishd/mgt/mgt_param_tbl.c
+++ b/bin/varnishd/mgt/mgt_param_tbl.c
@@ -307,6 +307,12 @@ struct parspec mgt_parspec[] = {
 		"backend request.",
 		0,
 		"3.5", "seconds" },
+	{ "connect_bindany", tweak_bool, &mgt_param.connect_bindany,
+		NULL, NULL,
+		"Bind any before connect: move the 64k local ports limit"
+		"to 64k connections per destination.",
+		0,
+		"off", "bool" },
 	{ "clock_skew", tweak_uint, &mgt_param.clock_skew,
 		"0", NULL,
 		"How much clockskew we are willing to accept between the "

--- a/include/tbl/params.h
+++ b/include/tbl/params.h
@@ -310,6 +310,21 @@ PARAM(
 	/* func */	NULL
 )
 PARAM(
+	/* name */	connect_bindany,
+	/* tweak */	tweak_bool,
+	/* var */	connect_bindany,
+	/* min */	none,
+	/* max */	none,
+	/* default */	off,
+	/* units */	bool,
+	/* flags */	00,
+	/* s-text */
+	"Bind any before connect: move the 64k local ports limit"
+	"to 64k connections per destination.\n",
+	/* l-text */	"",
+	/* func */	NULL
+)
+PARAM(
 	/* name */	critbit_cooloff,
 	/* tweak */	tweak_timeout,
 	/* var */	critbit_cooloff,

--- a/include/vtcp.h
+++ b/include/vtcp.h
@@ -53,7 +53,8 @@ int VTCP_check_hup(int sock);
 void VTCP_name(const struct suckaddr *addr, char *abuf, unsigned alen,
     char *pbuf, unsigned plen);
 int VTCP_connected(int s);
-int VTCP_connect(const struct suckaddr *name, int msec);
+int VTCP_bindany(int s, int pf);
+int VTCP_connect(const struct suckaddr *name, int msec, unsigned bindany);
 int VTCP_open(const char *addr, const char *def_port, double timeout,
     const char **err);
 void VTCP_close(int *s);

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -340,16 +340,15 @@ VTCP_connect(const struct suckaddr *name, int msec, unsigned bindany)
 			/* Timeout */
 			i = -1;
 			errno = ETIMEDOUT;
+			AZ(close(s));
 		} else {
 			i = VTCP_connected(s);
 		}
 		if (i >= 0)
 			return (s);
 		if (errno != EADDRNOTAVAIL && errno != ETIMEDOUT) {
-			AZ(close(s));
 			return (-1);
 		}
-		AZ(close(s));
 	}
 	return (-1);
 }

--- a/lib/libvarnish/vtcp.c
+++ b/lib/libvarnish/vtcp.c
@@ -248,7 +248,37 @@ VTCP_connected(int s)
 }
 
 int
-VTCP_connect(const struct suckaddr *name, int msec)
+VTCP_bindany(int s, int pf)
+{
+	int i, val;
+
+	val = 1;
+	if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &val, sizeof val) != 0) {
+		return (-1);
+	}
+
+	if (pf == PF_INET) {
+		struct sockaddr_in addr;
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = INADDR_ANY;
+		addr.sin_port = htons(0);
+		i = bind(s, (struct sockaddr *)&addr, sizeof addr);
+	}
+	else if (pf == PF_INET6) {
+		struct sockaddr_in6 addr;
+		addr.sin6_family = AF_INET6;
+		addr.sin6_addr = in6addr_any;
+		addr.sin6_port = htons(0);
+		i = bind(s, (struct sockaddr *)&addr, sizeof addr);
+	} else {
+		return (-1);
+	}
+
+	return (i);
+}
+
+int
+VTCP_connect(const struct suckaddr *name, int msec, unsigned bindany)
 {
 	int s, i;
 	struct pollfd fds[1];
@@ -263,45 +293,65 @@ VTCP_connect(const struct suckaddr *name, int msec)
 	AN(sa);
 	AN(sl);
 
-	s = socket(sa->sa_family, SOCK_STREAM, 0);
-	if (s < 0)
-		return (s);
+	for (int retry = 0; retry < 3; retry++) {
+		s = socket(sa->sa_family, SOCK_STREAM, 0);
+		if (s < 0)
+			return (s);
 
-	/* Set the socket non-blocking */
-	if (msec != 0)
-		(void)VTCP_nonblocking(s);
+		/* Set the socket non-blocking */
+		if (msec != 0)
+			(void)VTCP_nonblocking(s);
 
-	i = connect(s, sa, sl);
-	if (i == 0)
-		return (s);
-	if (errno != EINPROGRESS) {
+		/* Switch to the bind before connect logic */
+		if (bindany)
+			if (VTCP_bindany(s, sa->sa_family) != 0)
+				return (-1);
+
+		i = connect(s, sa, sl);
+		if (msec == 0) {
+			if (i == 0)
+				return (s);
+			if (errno == EADDRNOTAVAIL) {
+				AZ(close(s));
+				continue;
+			}
+		}
+		if (errno != EINPROGRESS) {
+			AZ(close(s));
+			return (-1);
+		}
+
+		if (msec < 0) {
+			/*
+			 * Caller is responsible for waiting and
+			 * calling VTCP_connected
+			 */
+			return (s);
+		}
+
+		assert(msec > 0);
+		/* Exercise our patience, polling for write */
+		fds[0].fd = s;
+		fds[0].events = POLLWRNORM;
+		fds[0].revents = 0;
+		i = poll(fds, 1, msec);
+
+		if (i == 0) {
+			/* Timeout */
+			i = -1;
+			errno = ETIMEDOUT;
+		} else {
+			i = VTCP_connected(s);
+		}
+		if (i >= 0)
+			return (s);
+		if (errno != EADDRNOTAVAIL && errno != ETIMEDOUT) {
+			AZ(close(s));
+			return (-1);
+		}
 		AZ(close(s));
-		return (-1);
 	}
-
-	if (msec < 0) {
-		/*
-		 * Caller is responsible for waiting and
-		 * calling VTCP_connected
-		 */
-		return (s);
-	}
-
-	assert(msec > 0);
-	/* Exercise our patience, polling for write */
-	fds[0].fd = s;
-	fds[0].events = POLLWRNORM;
-	fds[0].revents = 0;
-	i = poll(fds, 1, msec);
-
-	if (i == 0) {
-		/* Timeout, close and give up */
-		AZ(close(s));
-		errno = ETIMEDOUT;
-		return (-1);
-	}
-
-	return (VTCP_connected(s));
+	return (-1);
 }
 
 /*--------------------------------------------------------------------
@@ -348,7 +398,7 @@ vtcp_open_callback(void *priv, const struct suckaddr *sa)
 {
 	double *p = priv;
 
-	return (VTCP_connect(sa, (int)floor(*p * 1e3)));
+	return (VTCP_connect(sa, (int)floor(*p * 1e3), 0));
 }
 
 int


### PR DESCRIPTION
add connect_bindany parameter to change connect logic to backend 
It permit to move the 64k local ports limit to 64k connections per destination.

The full explanation:
https://idea.popcount.org/2014-04-03-bind-before-connect/
