### PR TITLE
Warn on duplicate imports with non-matching paths

### DIFF
--- a/bin/varnishtest/tests/m00001.vtc
+++ b/bin/varnishtest/tests/m00001.vtc
@@ -47,10 +47,24 @@ varnish v1 -cliok "vcl.discard vcl1"
 varnish v1 -cliok "vcl.list"
 varnish v1 -cliok "debug.vmod"
 
-varnish v1 -errvcl {Module std already imported.} {
+shell "cp $( echo ${vmod_std} | sed 's/std from//') ${tmpdir}"
+
+varnish v1 -errvcl {Warning: Module std imported from different location.} {
+	import ${vmod_std};
+	import std from "${tmpdir}";
+}
+
+varnish v1 -vcl+backend {
 	import ${vmod_std};
 	import ${vmod_std};
 }
+
+varnish v1 -vcl+backend {
+}
+
+varnish v1 -cliok "vcl.discard vcl4"
+varnish v1 -cliok "vcl.list"
+varnish v1 -cliok "debug.vmod"
 
 varnish v1 -errvcl {Symbol not found: 'std' (expected type BOOL):} {
 	import ${vmod_std};

--- a/bin/varnishtest/tests/m00001.vtc
+++ b/bin/varnishtest/tests/m00001.vtc
@@ -47,7 +47,7 @@ varnish v1 -cliok "vcl.discard vcl1"
 varnish v1 -cliok "vcl.list"
 varnish v1 -cliok "debug.vmod"
 
-shell "cp $( echo ${vmod_std} | sed 's/std from//') ${tmpdir}"
+shell "cp ${topbuild}/lib/libvmod_std/.libs/libvmod_std.so ${tmpdir}"
 
 varnish v1 -errvcl {Warning: Module std imported from different location.} {
 	import ${vmod_std};
@@ -59,13 +59,6 @@ varnish v1 -vcl+backend {
 	import ${vmod_std};
 }
 
-varnish v1 -vcl+backend {
-}
-
-varnish v1 -cliok "vcl.discard vcl4"
-varnish v1 -cliok "vcl.list"
-varnish v1 -cliok "debug.vmod"
-
 varnish v1 -errvcl {Symbol not found: 'std' (expected type BOOL):} {
 	import ${vmod_std};
 
@@ -75,6 +68,9 @@ varnish v1 -errvcl {Symbol not found: 'std' (expected type BOOL):} {
 	}
 }
 
+varnish v1 -vcl+backend {
+}
+varnish v1 -cliok "vcl.discard vcl4"
 varnish v1 -cliok "debug.vmod"
 varnish v1 -cliok "vcl.list"
 varnish v1 -expect vmods == 0

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -139,6 +139,9 @@ struct symbol {
 	/* SYM_VAR */
 	const struct var		*var;
 	unsigned			r_methods;
+
+	/* SYM_VMOD */
+	const char 			*path;
 };
 
 VTAILQ_HEAD(tokenhead, token);


### PR DESCRIPTION
Instead of failing on same-named import statements, check if the import path matches and warn if it doesn't.
This warns the user if she's not loading the vmod she is expecting, but allows the first import to override later imports.