### PR TITLE
dot-include relative to source file location

### DIFF
--- a/bin/varnishtest/tests/v00046.vtc
+++ b/bin/varnishtest/tests/v00046.vtc
@@ -1,0 +1,70 @@
+varnishtest "Test relative to vcl_dir, dot-include and absolute includes"
+
+# relative plain
+shell "true > ${tmpdir}/_start.vcl"
+varnish v1 -arg "-p vcl_dir=${tmpdir}" -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "_start.vcl" ;
+}
+
+# absolute include
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "${tmpdir}/_start.vcl" ;
+}
+
+# absolute -> relative include
+shell "mkdir -p ${tmpdir}/1/2/3"
+shell "true  > ${tmpdir}/1/2/b.vcl"
+shell "echo 'include \"./2/b.vcl\";' > ${tmpdir}/1/a.vcl"
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "${tmpdir}/1/a.vcl" ;
+}
+
+# same but relative to vcl_dir
+shell "echo 'include \"1/2/b.vcl\";' > ${tmpdir}/1/ab.vcl"
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "1/ab.vcl" ;
+}
+
+# dot-relative -> relative
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "1/a.vcl" ;
+}
+
+# relative -> relative -> relative
+shell "echo 'include \"./3/c.vcl\";' > ${tmpdir}/1/2/b.vcl"
+shell "true  > ${tmpdir}/1/2/3/c.vcl"
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "1/a.vcl" ;
+}
+
+# relative -> absolute
+shell "echo 'include \"${tmpdir}/1/2/3/c.vcl\";' > ${tmpdir}/1/aa.vcl"
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "1/aa.vcl" ;
+}
+
+# relative -> absolute -> relative
+shell "echo 'include \"${tmpdir}/1/2/b.vcl\";' > ${tmpdir}/1/aaa.vcl"
+varnish v1 -vcl {
+	backend b { .host = "127.0.0.1"; }
+	include "1/aaa.vcl" ;
+}
+
+# includes and parses out
+shell "echo 'zool' > ${tmpdir}/1/2/3/c.vcl"
+varnish v1 -errvcl {Found: 'zool' at} {
+	backend b { .host = "127.0.0.1"; }
+	include "1/a.vcl";
+}
+
+shell "rm -f ${tmpdir}/a"
+shell "rm -f ${tmpdir}/_start.vcl"
+
+

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -456,7 +456,9 @@ vcc_destroy_source(struct source *sp)
  *
  */
 
-static struct vsb *vcc_include_path(const struct vcc *tl, const char *fn) {
+static struct vsb *
+vcc_include_path(const struct vcc *tl, const char *fn)
+{
 	struct vsb *vsb;
 	char *p, *relp;
 	const char *fsrc;

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -464,33 +464,29 @@ vcc_include_path(const struct vcc *tl, const char *fn)
 	const char *fsrc;
 	vsb = VSB_new_auto();
 	AN(vsb);
-	VSB_clear(vsb);
-	/* absolute paths .. are relative to / */
-	if (fn[0] == '/') {
-		fsrc = fn + 1;
-		goto dirname;
-	}
 
 	/* relative paths are relative to vcl_dir,
-	 * unless they start with './', in which case relative to  includers source path */
+	 * unless they start with './', in which case relative to includers source path */
 	relp = tl->vcl_dir;
 	if (fn[0] == '.' && fn[1] == '/') {
 		if (tl->src->path)
 			relp = tl->src->path;
+		VSB_cat(vsb, relp);
+		/* including source may have a relative prefix we need to add */
+		fsrc = tl->src->name;
+		if (fsrc[0] == '/') {
+			VSB_finish(vsb);
+			return vsb;
+		}
+	} else if (fn[0] == '/') {
+		/* absolute paths .. are relative to / */
+		fsrc = fn + 1;
 	} else {
 		VSB_cat(vsb, tl->vcl_dir);
 		VSB_finish(vsb);
 		return vsb;
 	}
 
-	VSB_cat(vsb, relp);
-	/* including source may have a relative prefix we need to add */
-	fsrc = tl->src->name;
-	if (fsrc[0] == '/') {
-		VSB_finish(vsb);
-		return vsb;
-	}
-dirname:
 	p = strrchr(fsrc, '/');
 	if (p == NULL) {
 		VSB_finish(vsb);

--- a/lib/libvcc/vcc_compile.c
+++ b/lib/libvcc/vcc_compile.c
@@ -422,7 +422,7 @@ EmitStruct(const struct vcc *tl)
 /*--------------------------------------------------------------------*/
 
 static struct source *
-vcc_new_source(const char *b, const char *e, const char *name)
+vcc_new_source(const char *b, const char *e, const char *name, const char *path)
 {
 	struct source *sp;
 
@@ -434,6 +434,10 @@ vcc_new_source(const char *b, const char *e, const char *name)
 	AN(sp->name);
 	sp->b = b;
 	sp->e = e;
+	if (path != NULL) {
+		sp->path = strdup(path);
+		AN(sp->path);
+	}
 	return (sp);
 }
 
@@ -447,6 +451,55 @@ vcc_destroy_source(struct source *sp)
 	free(sp);
 }
 
+/*--------------------------------------------------------------------
+ * Include files relative to source's path or vcl_dir
+ *
+ */
+
+static struct vsb *vcc_include_path(const struct vcc *tl, const char *fn) {
+	struct vsb *vsb;
+	char *p, *relp;
+	const char *fsrc;
+	vsb = VSB_new_auto();
+	AN(vsb);
+	VSB_clear(vsb);
+	/* absolute paths .. are relative to / */
+	if (fn[0] == '/') {
+		fsrc = fn + 1;
+		goto dirname;
+	}
+
+	/* relative paths are relative to vcl_dir,
+	 * unless they start with './', in which case relative to  includers source path */
+	relp = tl->vcl_dir;
+	if (fn[0] == '.' && fn[1] == '/') {
+		if (tl->src->path)
+			relp = tl->src->path;
+	} else {
+		VSB_cat(vsb, tl->vcl_dir);
+		VSB_finish(vsb);
+		return vsb;
+	}
+
+	VSB_cat(vsb, relp);
+	/* including source may have a relative prefix we need to add */
+	fsrc = tl->src->name;
+	if (fsrc[0] == '/') {
+		VSB_finish(vsb);
+		return vsb;
+	}
+dirname:
+	p = strrchr(fsrc, '/');
+	if (p == NULL) {
+		VSB_finish(vsb);
+		return vsb;
+	}
+	VSB_putc(vsb, '/');
+	VSB_bcat(vsb, fsrc, p - fsrc);
+	VSB_finish(vsb);
+	return vsb;
+}
+
 /*--------------------------------------------------------------------*/
 
 static struct source *
@@ -454,19 +507,23 @@ vcc_file_source(const struct vcc *tl, struct vsb *sb, const char *fn)
 {
 	char *f;
 	struct source *sp;
+	struct vsb *fb;
 
 	if (!tl->unsafe_path && strchr(fn, '/') != NULL) {
 		VSB_printf(sb, "Include path is unsafe '%s'\n", fn);
 		return (NULL);
 	}
-	f = VFIL_readfile(tl->vcl_dir, fn, NULL);
+	fb = vcc_include_path(tl, fn);
+	f = VFIL_readfile(VSB_data(fb), fn, NULL);
 	if (f == NULL) {
 		VSB_printf(sb, "Cannot read file '%s': %s\n",
 		    fn, strerror(errno));
+		VSB_delete(fb);
 		return (NULL);
 	}
-	sp = vcc_new_source(f, NULL, fn);
+	sp = vcc_new_source(f, NULL, fn, VSB_data(fb));
 	sp->freeit = f;
+	VSB_delete(fb);
 	return (sp);
 }
 
@@ -649,7 +706,7 @@ vcc_CompileSource(const struct vcc *tl0, struct vsb *sb, struct source *sp)
 		return (vcc_DestroyTokenList(tl, NULL));
 
 	/* Register and lex the builtin VCL */
-	sp = vcc_new_source(tl->builtin_vcl, NULL, "Builtin");
+	sp = vcc_new_source(tl->builtin_vcl, NULL, "Builtin", NULL);
 	assert(sp != NULL);
 	VTAILQ_INSERT_TAIL(&tl->sources, sp, list);
 	sp->idx = tl->nsources++;
@@ -764,7 +821,7 @@ VCC_Compile(const struct vcc *tl, struct vsb *sb, const char *b)
 	struct source *sp;
 	char *r;
 
-	sp = vcc_new_source(b, NULL, "input");
+	sp = vcc_new_source(b, NULL, "input", NULL);
 	if (sp == NULL)
 		return (NULL);
 	r = vcc_CompileSource(tl, sb, sp);

--- a/lib/libvcc/vcc_compile.h
+++ b/lib/libvcc/vcc_compile.h
@@ -87,6 +87,7 @@ struct source {
 	const char		*e;
 	unsigned		idx;
 	char			*freeit;
+	char			*path;
 };
 
 struct token {


### PR DESCRIPTION
Relative includes as discussed on VDD;

if I have a subdirectory `foo`:
  foo/foo.vcl
  foo/bar.vcl

default.vcl:
```
include foo/foo.vcl
```

foo:
```
include "./bar.vcl";
```

This patch
* makes it clear that it is source-relative includes we want only when we prefix the included file with dot slash
* doesn't break existing scripts relative to vcl_dir, keeping the old behavior for relative paths without './'
* allows the move of subdir `foo/` without changing all includes in `foo/*.vcl`