### PR TITLE
Pass the busyobj pointer also for vdir_pick_be.

### DIFF
--- a/lib/libvmod_directors/hash.c
+++ b/lib/libvmod_directors/hash.c
@@ -97,6 +97,7 @@ vmod_hash_backend(VRT_CTX, struct vmod_directors_hash *rr,
 	double r;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_ORNULL(ctx->bo, BUSYOBJ_MAGIC);
 
 	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_HASH_MAGIC);
 	SHA256_Init(&sha_ctx);
@@ -113,6 +114,6 @@ vmod_hash_backend(VRT_CTX, struct vmod_directors_hash *rr,
 	r = vbe32dec(sha256);
 	r = scalbn(r, -32);
 	assert(r >= 0 && r <= 1.0);
-	be = vdir_pick_be(rr->vd, r);
+	be = vdir_pick_be(rr->vd, r, ctx->bo);
 	return (be);
 }

--- a/lib/libvmod_directors/random.c
+++ b/lib/libvmod_directors/random.c
@@ -71,7 +71,7 @@ vmod_random_resolve(const struct director *dir, struct worker *wrk,
 	CAST_OBJ_NOTNULL(rr, dir->priv, VMOD_DIRECTORS_RANDOM_MAGIC);
 	r = scalbn(random(), -31);
 	assert(r >= 0 && r < 1.0);
-	be = vdir_pick_be(rr->vd, r);
+	be = vdir_pick_be(rr->vd, r, bo);
 	return (be);
 }
 

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -177,7 +177,7 @@ vdir_pick_by_weight(const struct vdir *vd, double w,
 }
 
 VCL_BACKEND
-vdir_pick_be(struct vdir *vd, double w)
+vdir_pick_be(struct vdir *vd, double w, const struct busyobj *bo)
 {
 	unsigned u;
 	double tw = 0.0;
@@ -185,7 +185,7 @@ vdir_pick_be(struct vdir *vd, double w)
 
 	vdir_lock(vd);
 	for (u = 0; u < vd->n_backend; u++) {
-		if (vd->backend[u]->healthy(vd->backend[u], NULL, NULL)) {
+		if (vd->backend[u]->healthy(vd->backend[u], bo, NULL)) {
 			vbit_clr(vd->vbm, u);
 			tw += vd->weight[u];
 		} else

--- a/lib/libvmod_directors/vdir.h
+++ b/lib/libvmod_directors/vdir.h
@@ -49,4 +49,4 @@ void vdir_unlock(struct vdir *vd);
 unsigned vdir_add_backend(struct vdir *, VCL_BACKEND be, double weight);
 unsigned vdir_any_healthy(struct vdir *, const struct busyobj *,
     double *changed);
-VCL_BACKEND vdir_pick_be(struct vdir *, double w);
+VCL_BACKEND vdir_pick_be(struct vdir *, double w, const struct busyobj *);


### PR DESCRIPTION
It's needed for the vdi_healthy_f invocation.

See discussion on varnish-dev: https://www.varnish-cache.org/lists/pipermail/varnish-dev/2015-December/008720.html