### PR TITLE
Use a rwlock for the directors VMOD, and add remove_backend() to each director.

### DIFF
--- a/bin/varnishtest/tests/d00000.vtc
+++ b/bin/varnishtest/tests/d00000.vtc
@@ -31,6 +31,15 @@ varnish v1 -vcl+backend {
 		rr.add_backend(s4);
 	}
 
+	sub vcl_recv {
+		if (req.method == "DELETE") {
+			rr.remove_backend(s1);
+			rr.remove_backend(s2);
+			rr.remove_backend(s3);
+			return(synth(204));
+		}
+	}
+
 	sub vcl_backend_fetch {
 		set bereq.backend = rr.backend();
 	}
@@ -63,4 +72,15 @@ client c2 {
 	txreq -url "/foo22"
 	rxresp
 	expect resp.bodylen == 2
+} -run
+
+server s4 -start
+
+client c3 {
+	txreq -req "DELETE"
+	rxresp
+	expect resp.status == 204
+	txreq -url "/foo31"
+	rxresp
+	expect resp.bodylen == 4
 } -run

--- a/bin/varnishtest/tests/d00001.vtc
+++ b/bin/varnishtest/tests/d00001.vtc
@@ -26,6 +26,10 @@ varnish v1 -vcl+backend {
 	}
 
 	sub vcl_recv {
+		if (req.method == "DELETE") {
+			fb1.remove_backend(s2);
+			return(synth(204));
+		}
 		return (pass);
 	}
 
@@ -58,4 +62,16 @@ client c1 {
 	txreq
 	rxresp
 	expect resp.http.foo == "1"
+} -run
+
+varnish v1 -cliok "backend.set_health s1 sick"
+server s3 -start
+
+client c1 {
+	txreq -req "DELETE"
+	rxresp
+	expect resp.status == 204
+	txreq
+	rxresp
+	expect resp.http.foo == "3"
 } -run

--- a/bin/varnishtest/tests/d00002.vtc
+++ b/bin/varnishtest/tests/d00002.vtc
@@ -33,3 +33,46 @@ client c1 {
 	rxresp
 	expect resp.http.where == "foo-->s1"
 } -run
+
+server s1 -start
+server s2 {
+	loop 20 {
+		rxreq
+		txresp
+	}
+} -start
+
+varnish v1 -vcl+backend {
+	import ${vmod_directors};
+
+	sub vcl_init {
+		new foo = directors.random();
+		foo.add_backend(s1, 1);
+		foo.add_backend(s2, 1);
+	}
+
+	sub vcl_recv {
+		if (req.method == "DELETE") {
+			foo.remove_backend(s1);
+			return(synth(204));
+		}
+		set req.backend_hint = foo.backend();
+		return (pass);
+	}
+
+	sub vcl_backend_response {
+		set beresp.http.where = bereq.backend + "-->" + beresp.backend;
+	}
+}
+
+client c1 {
+	txreq -req "DELETE"
+	rxresp
+	expect resp.status == 204
+	loop 20 {
+		txreq
+		rxresp
+		expect resp.status == 200
+		expect resp.http.where == "foo-->s2"
+	}
+} -run

--- a/bin/varnishtest/tests/d00003.vtc
+++ b/bin/varnishtest/tests/d00003.vtc
@@ -30,6 +30,10 @@ varnish v1 -vcl+backend {
 	}
 
 	sub vcl_recv {
+		if (req.method == "DELETE") {
+			h1.remove_backend(s1);
+			return(synth(204));
+		}
 		if (req.url == "/nohdr") {
 			set req.backend_hint = h1.backend(req.http.Void);
 		} else if (req.url == "/emptystring") {
@@ -73,4 +77,28 @@ client c1 {
 	txreq -url /ip
 	rxresp
 	expect resp.http.foo == "9"
+} -run
+
+server s2 -start
+
+client c1 {
+	txreq -req "DELETE"
+	rxresp
+	expect resp.status == 204
+
+	txreq
+	rxresp
+	expect resp.http.foo == "2"
+
+	txreq
+	rxresp
+	expect resp.http.foo == "4"
+
+	txreq
+	rxresp
+	expect resp.http.foo == "6"
+
+	txreq
+	rxresp
+	expect resp.http.foo == "8"
 } -run

--- a/lib/libvmod_directors/fall_back.c
+++ b/lib/libvmod_directors/fall_back.c
@@ -117,6 +117,15 @@ vmod_fallback_add_backend(VRT_CTX,
 	(void)vdir_add_backend(rr->vd, be, 0.0);
 }
 
+VCL_VOID __match_proto__()
+vmod_fallback_remove_backend(VRT_CTX,
+    struct vmod_directors_fallback *fb, VCL_BACKEND be)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(fb, VMOD_DIRECTORS_FALLBACK_MAGIC);
+	(void)vdir_remove_backend(fb->vd, be);
+}
+
 VCL_BACKEND __match_proto__()
 vmod_fallback_backend(VRT_CTX,
     struct vmod_directors_fallback *rr)

--- a/lib/libvmod_directors/fall_back.c
+++ b/lib/libvmod_directors/fall_back.c
@@ -66,7 +66,7 @@ vmod_fallback_resolve(const struct director *dir, struct worker *wrk,
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	CAST_OBJ_NOTNULL(rr, dir->priv, VMOD_DIRECTORS_FALLBACK_MAGIC);
-	vdir_lock(rr->vd);
+	vdir_rdlock(rr->vd);
 	for (u = 0; u < rr->vd->n_backend; u++) {
 		be = rr->vd->backend[u];
 		CHECK_OBJ_NOTNULL(be, DIRECTOR_MAGIC);

--- a/lib/libvmod_directors/hash.c
+++ b/lib/libvmod_directors/hash.c
@@ -85,6 +85,16 @@ vmod_hash_add_backend(VRT_CTX,
 	(void)vdir_add_backend(rr->vd, be, w);
 }
 
+VCL_VOID __match_proto__()
+vmod_hash_remove_backend(VRT_CTX,
+    struct vmod_directors_hash *rr, VCL_BACKEND be)
+{
+
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_HASH_MAGIC);
+	(void)vdir_remove_backend(rr->vd, be);
+}
+
 VCL_BACKEND __match_proto__()
 vmod_hash_backend(VRT_CTX, struct vmod_directors_hash *rr,
     const char *arg, ...)

--- a/lib/libvmod_directors/random.c
+++ b/lib/libvmod_directors/random.c
@@ -113,6 +113,14 @@ vmod_random_add_backend(VRT_CTX,
 	(void)vdir_add_backend(rr->vd, be, w);
 }
 
+VCL_VOID vmod_random_remove_backend(VRT_CTX,
+    struct vmod_directors_random *rr, VCL_BACKEND be)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_RANDOM_MAGIC);
+	(void)vdir_remove_backend(rr->vd, be);
+}
+
 VCL_BACKEND __match_proto__()
 vmod_random_backend(VRT_CTX, struct vmod_directors_random *rr)
 {

--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -120,6 +120,15 @@ vmod_round_robin_add_backend(VRT_CTX,
 	(void)vdir_add_backend(rr->vd, be, 0.0);
 }
 
+VCL_VOID __match_proto__()
+vmod_round_robin_remove_backend(VRT_CTX,
+    struct vmod_directors_round_robin *rr, VCL_BACKEND be)
+{
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+	CHECK_OBJ_NOTNULL(rr, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
+	(void)vdir_remove_backend(rr->vd, be);
+}
+
 VCL_BACKEND __match_proto__()
 vmod_round_robin_backend(VRT_CTX,
     struct vmod_directors_round_robin *rr)

--- a/lib/libvmod_directors/round_robin.c
+++ b/lib/libvmod_directors/round_robin.c
@@ -67,7 +67,7 @@ vmod_rr_resolve(const struct director *dir, struct worker *wrk,
 	CHECK_OBJ_NOTNULL(wrk, WORKER_MAGIC);
 	CHECK_OBJ_NOTNULL(bo, BUSYOBJ_MAGIC);
 	CAST_OBJ_NOTNULL(rr, dir->priv, VMOD_DIRECTORS_ROUND_ROBIN_MAGIC);
-	vdir_lock(rr->vd);
+	vdir_rdlock(rr->vd);
 	for (u = 0; u < rr->vd->n_backend; u++) {
 		rr->nxt %= rr->vd->n_backend;
 		be = rr->vd->backend[rr->nxt];

--- a/lib/libvmod_directors/vdir.c
+++ b/lib/libvmod_directors/vdir.c
@@ -138,6 +138,32 @@ vdir_add_backend(struct vdir *vd, VCL_BACKEND be, double weight)
 }
 
 unsigned
+vdir_remove_backend(struct vdir *vd, VCL_BACKEND be)
+{
+        unsigned u, n;
+
+        CHECK_OBJ_NOTNULL(vd, VDIR_MAGIC);
+        if (be == NULL)
+                return vd->n_backend;
+        CHECK_OBJ(be, DIRECTOR_MAGIC);
+        vdir_wrlock(vd);
+        for (u = 0; u < vd->n_backend; u++)
+                if (vd->backend[u] == be)
+                        break;
+        if (u == vd->n_backend) {
+                vdir_unlock(vd);
+                return vd->n_backend;
+        }
+        vd->total_weight -= vd->weight[u];
+        n = vd->n_backend - u - 1;
+        memmove(&vd->backend[u], &vd->backend[u+1], n * sizeof(vd->backend[0]));
+        memmove(&vd->weight[u], &vd->weight[u+1], n * sizeof(vd->weight[0]));
+        vd->n_backend--;
+        vdir_unlock(vd);
+        return vd->n_backend;
+}
+
+unsigned
 vdir_any_healthy(struct vdir *vd, const struct busyobj *bo, double *changed)
 {
 	unsigned retval = 0;

--- a/lib/libvmod_directors/vdir.h
+++ b/lib/libvmod_directors/vdir.h
@@ -31,7 +31,7 @@ struct vbitmap;
 struct vdir {
 	unsigned				magic;
 #define VDIR_MAGIC				0x99f4b726
-	pthread_mutex_t				mtx;
+	pthread_rwlock_t			mtx;
 	unsigned				n_backend;
 	unsigned				l_backend;
 	VCL_BACKEND				*backend;
@@ -44,7 +44,8 @@ struct vdir {
 void vdir_new(struct vdir **vdp, const char *name, const char *vcl_name,
     vdi_healthy_f *healthy, vdi_resolve_f *resolve, void *priv);
 void vdir_delete(struct vdir **vdp);
-void vdir_lock(struct vdir *vd);
+void vdir_rdlock(struct vdir *vd);
+void vdir_wrlock(struct vdir *vd);
 void vdir_unlock(struct vdir *vd);
 unsigned vdir_add_backend(struct vdir *, VCL_BACKEND be, double weight);
 unsigned vdir_any_healthy(struct vdir *, const struct busyobj *,

--- a/lib/libvmod_directors/vdir.h
+++ b/lib/libvmod_directors/vdir.h
@@ -48,6 +48,7 @@ void vdir_rdlock(struct vdir *vd);
 void vdir_wrlock(struct vdir *vd);
 void vdir_unlock(struct vdir *vd);
 unsigned vdir_add_backend(struct vdir *, VCL_BACKEND be, double weight);
+unsigned vdir_remove_backend(struct vdir *, VCL_BACKEND be);
 unsigned vdir_any_healthy(struct vdir *, const struct busyobj *,
     double *changed);
 VCL_BACKEND vdir_pick_be(struct vdir *, double w, const struct busyobj *);

--- a/lib/libvmod_directors/vmod.vcc
+++ b/lib/libvmod_directors/vmod.vcc
@@ -72,6 +72,14 @@ Example
 	vdir.add_backend(backend1);
 	vdir.add_backend(backend2);
 
+$Method VOID .remove_backend(BACKEND)
+
+Description
+	Remove a backend from the round-robin director.
+Example
+	vdir.remove_backend(backend1);
+	vdir.remove_backend(backend2);
+
 $Method BACKEND .backend()
 
 Description
@@ -102,6 +110,14 @@ Description
 Example
 	vdir.add_backend(backend1);
 	vdir.add_backend(backend2);
+
+$Method VOID .remove_backend(BACKEND)
+
+Description
+	Remove a backend from the director.
+Example
+	vdir.remove_backend(backend1);
+	vdir.remove_backend(backend2);
 
 $Method BACKEND .backend()
 
@@ -136,6 +152,13 @@ Example
 	vdir.add_backend(backend1, 10.0);
 	vdir.add_backend(backend2, 5.0);
 
+$Method VOID .remove_backend(BACKEND)
+
+Description
+	Remove a backend from the director.
+Example
+	vdir.remove_backend(backend1);
+	vdir.remove_backend(backend2);
 
 $Method BACKEND .backend()
 
@@ -170,6 +193,13 @@ Example
 	vdir.add_backend(backend1, 1.0);
 	vdir.add_backend(backend2, 1.0);
 
+$Method VOID .remove_backend(BACKEND)
+
+Description
+	Remove a backend from the director.
+Example
+	vdir.remove_backend(backend1);
+	vdir.remove_backend(backend2);
 
 $Method BACKEND .backend(STRING_LIST)
 


### PR DESCRIPTION
These two changes were agreed upon at VDD last week, and they correspond to the two patches I sent in "old style" fashion to varnish-dev on December 4th and 6th (it appears to me that PRs are preferred now).

add_backend() and the new remove_backend() use a wrlock to access the backend lists, and all other methods use a rdlock. remove_backend() has been added to each director in the VMOD.