### PR TITLE
Assert sma_alloc size != 0

### DIFF
--- a/bin/varnishd/storage/storage_malloc.c
+++ b/bin/varnishd/storage/storage_malloc.c
@@ -66,6 +66,8 @@ sma_alloc(const struct stevedore *st, size_t size)
 	struct sma *sma = NULL;
 	void *p;
 
+	assert(size != 0);
+
 	CAST_OBJ_NOTNULL(sma_sc, st->priv, SMA_SC_MAGIC);
 	Lck_Lock(&sma_sc->sma_mtx);
 	sma_sc->stats->c_req++;


### PR DESCRIPTION
If some calls sma_alloc with size = 0, counter sma_sc->stats->g_alloc
will be incremented and never decremented, because zero-sized
malloc can't be sma_freed.