### PR TITLE
Test for range request "bytes=0-"

### DIFF
--- a/bin/varnishtest/tests/c00034.vtc
+++ b/bin/varnishtest/tests/c00034.vtc
@@ -112,9 +112,15 @@ client c1 {
 	expect resp.status == 206
 	expect resp.bodylen == 100
 	expect resp.http.content-range == "bytes 0-99/100"
+
+	txreq -hdr "Range: bytes=0-"
+	rxresp
+	expect resp.status == 206
+	expect resp.bodylen == 100
+	expect resp.http.content-range == "bytes 0-99/100"
 } -run
 
-varnish v1 -expect s_resp_bodybytes == 401
+varnish v1 -expect s_resp_bodybytes == 501
 
 # Test Range streaming with streaming objects with C-L
 


### PR DESCRIPTION
This (useless) range request is send by Chrome with HTML5 Video.
This was not working correctly in 4.0 and was fixed somewhere
in master.