### PR TITLE
Fix int mistakenly used as unsigned long

### DIFF
--- a/bin/varnishstat/varnishstat_curses.c
+++ b/bin/varnishstat/varnishstat_curses.c
@@ -540,7 +540,7 @@ static void
 print_duration(WINDOW *w, time_t t)
 {
 
-	wprintw(w, "%4lu+%02lu:%02lu:%02lu",
+	wprintw(w, "%4d+%02d:%02d:%02d",
 	    t / 86400, (t % 86400) / 3600, (t % 3600) / 60, t % 60);
 }
 


### PR DESCRIPTION
This was detected by building on FreeBSD 10.x i386

This has only been build tested and not yet verified further.