### PR TITLE
build: support for asan/tsan/msan/ubsan and gcov

### DIFF
--- a/bin/varnishadm/Makefile.am
+++ b/bin/varnishadm/Makefile.am
@@ -13,9 +13,19 @@ varnishadm_SOURCES = \
 	$(top_srcdir)/lib/libvarnish/vtcp.c \
 	$(top_srcdir)/lib/libvarnish/vss.c
 
-varnishadm_CFLAGS = @LIBEDIT_CFLAGS@
+varnishadm_CFLAGS = @LIBEDIT_CFLAGS@ \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
 
 varnishadm_LDADD = \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
-	${PTHREAD_LIBS} ${RT_LIBS} ${NET_LIBS} @LIBEDIT_LIBS@ ${LIBM}
+	${PTHREAD_LIBS} ${RT_LIBS} ${NET_LIBS} @LIBEDIT_LIBS@ ${LIBM} \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@

--- a/bin/varnishd/Makefile.am
+++ b/bin/varnishd/Makefile.am
@@ -131,8 +131,13 @@ nobase_pkginclude_HEADERS = \
 
 varnishd_CFLAGS = \
 	@PCRE_CFLAGS@ \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@ \
 	-DVARNISHD_IS_NOT_A_VMOD \
-        -DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
+	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
 	-DVARNISH_VMOD_DIR='"${pkglibdir}/vmods"' \
 	-DVARNISH_VCL_DIR='"${varnishconfdir}"'
 
@@ -143,6 +148,11 @@ varnishd_LDADD = \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 	$(top_builddir)/lib/libvcc/libvcc.la \
 	$(top_builddir)/lib/libvgz/libvgz.la \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@ \
 	@JEMALLOC_LDADD@ \
 	@PCRE_LIBS@ \
 	${DL_LIBS} ${PTHREAD_LIBS} ${NET_LIBS} ${LIBM} ${LIBUMEM}

--- a/bin/varnishhist/Makefile.am
+++ b/bin/varnishhist/Makefile.am
@@ -16,10 +16,22 @@ varnishhist_SOURCES = varnishhist.c \
 	$(top_srcdir)/lib/libvarnish/flopen.c \
 	$(top_srcdir)/lib/libvarnishtools/vut.c
 
+varnishhist_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
 varnishhist_LDADD = \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 	-lm \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@ \
 	@CURSES_LIB@ ${RT_LIBS} ${PTHREAD_LIBS}
 
 noinst_PROGRAMS = varnishhist_opt2rst

--- a/bin/varnishlog/Makefile.am
+++ b/bin/varnishlog/Makefile.am
@@ -18,9 +18,21 @@ varnishlog_SOURCES = \
 	$(top_srcdir)/lib/libvarnish/vpf.c \
 	$(top_srcdir)/lib/libvarnish/vtim.c
 
+varnishlog_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
 varnishlog_LDADD = \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@ \
 	${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
 
 noinst_PROGRAMS = varnishlog_opt2rst

--- a/bin/varnishncsa/Makefile.am
+++ b/bin/varnishncsa/Makefile.am
@@ -20,9 +20,21 @@ varnishncsa_SOURCES = \
 	$(top_srcdir)/lib/libvarnish/vtim.c \
 	$(top_srcdir)/lib/libvarnish/vsb.c
 
+varnishncsa_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
 varnishncsa_LDADD = \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@ \
 	${RT_LIBS} ${LIBM}
 
 noinst_PROGRAMS = varnishncsa_opt2rst

--- a/bin/varnishstat/Makefile.am
+++ b/bin/varnishstat/Makefile.am
@@ -15,9 +15,21 @@ varnishstat_SOURCES = \
 	$(top_srcdir)/lib/libvarnish/version.c \
 	$(top_srcdir)/lib/libvarnish/vtim.c
 
+varnishstat_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
 varnishstat_LDADD = \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 	@CURSES_LIB@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
 
 noinst_PROGRAMS = vsc2rst

--- a/bin/varnishtest/Makefile.am
+++ b/bin/varnishtest/Makefile.am
@@ -42,9 +42,19 @@ varnishtest_LDADD = \
 		$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 		$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
 		$(top_builddir)/lib/libvgz/libvgz.la \
+		@ASAN_LDFLAGS@ \
+		@MSAN_LDFLAGS@ \
+		@TSAN_LDFLAGS@ \
+		@UBSAN_LDFLAGS@ \
+		@COVERAGE_LDFLAGS@ \
 		${LIBM} ${PTHREAD_LIBS}
 
 varnishtest_CFLAGS = \
+		@ASAN_CFLAGS@ \
+		@MSAN_CFLAGS@ \
+		@TSAN_CFLAGS@ \
+		@UBSAN_CFLAGS@ \
+		@COVERAGE_CFLAGS@ \
 		-DTOP_BUILDDIR='"${top_builddir}"'
 
 EXTRA_DIST = $(top_srcdir)/bin/varnishtest/tests/*.vtc \

--- a/bin/varnishtop/Makefile.am
+++ b/bin/varnishtop/Makefile.am
@@ -18,9 +18,21 @@ varnishtop_SOURCES = varnishtop.c \
 	$(top_srcdir)/lib/libvarnish/vsb.c
 
 
+varnishtop_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
 varnishtop_LDADD = \
 	$(top_builddir)/lib/libvarnishcompat/libvarnishcompat.la \
 	$(top_builddir)/lib/libvarnishapi/libvarnishapi.la \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@ \
 	@CURSES_LIB@ ${RT_LIBS} ${LIBM} ${PTHREAD_LIBS}
 
 noinst_PROGRAMS = varnishtop_opt2rst

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,56 @@ if test "$ac_cv_have_viz" = no; then
 fi
 CFLAGS="${save_CFLAGS}"
 
+UBSAN_CFLAGS=
+UBSAN_LDFLAGS=
+AC_ARG_ENABLE(ubsan,
+	AS_HELP_STRING([--enable-ubsan],[enable undefined behavior sanitizer (default is NO)]),
+	CFLAGS="${CFLAGS} -fPIC"
+	UBSAN_CFLAGS="-fsanitize=undefined -fPIE -fno-omit-frame-pointer"
+	UBSAN_LDFLAGS="-fsanitize=undefined -pie")
+AC_SUBST(UBSAN_CFLAGS)
+AC_SUBST(UBSAN_LDFLAGS)
+
+TSAN_CFLAGS=
+TSAN_LDFLAGS=
+AC_ARG_ENABLE(tsan,
+	AS_HELP_STRING([--enable-tsan],[enable thread sanitizer (default is NO)]),
+	CFLAGS="${CFLAGS} -fPIC"
+	TSAN_CFLAGS="-fsanitize=thread -fPIE -fno-omit-frame-pointer"
+	TSAN_LDFLAGS="-fsanitize=thread -pie")
+AC_SUBST(TSAN_CFLAGS)
+AC_SUBST(TSAN_LDFLAGS)
+
+ASAN_CFLAGS=
+ASAN_LDFLAGS=
+AC_ARG_ENABLE(asan,
+	AS_HELP_STRING([--enable-asan],[enable address sanitizer (default is NO)]),
+	CFLAGS="${CFLAGS} -fPIC"
+	ASAN_CFLAGS="-fsanitize=address -fPIE -fno-omit-frame-pointer"
+	ASAN_LDFLAGS="-fsanitize=address -pie")
+AC_SUBST(ASAN_CFLAGS)
+AC_SUBST(ASAN_LDFLAGS)
+
+MSAN_CFLAGS=
+MSAN_LDFLAGS=
+AC_ARG_ENABLE(msan,
+	AS_HELP_STRING([--enable-msan],[enable memory sanitizer (default is NO)]),
+	CFLAGS="${CFLAGS} -fPIC"
+	MSAN_CFLAGS="-fsanitize=memory -fPIE -fno-omit-frame-pointer"
+	MSAN_LDFLAGS="-fsanitize=memory -pie")
+AC_SUBST(MSAN_CFLAGS)
+AC_SUBST(MSAN_LDFLAGS)
+
+COVERAGE_CFLAGS=
+COVERAGE_LDFLAGS=
+AC_ARG_ENABLE(coverage,
+    AS_HELP_STRING([--enable-coverage],
+	[enable gcov metrics (default is NO)]),
+	COVERAGE_CFLAGS="-fprofile-arcs -ftest-coverage"
+	COVERAGE_LDFLAGS="-lgcov -coverage")
+AC_SUBST(COVERAGE_CFLAGS)
+AC_SUBST(COVERAGE_LDFLAGS)
+
 # Use jemalloc on Linux
 JEMALLOC_LDADD=
 AC_ARG_WITH([jemalloc],

--- a/lib/libvarnish/Makefile.am
+++ b/lib/libvarnish/Makefile.am
@@ -36,8 +36,19 @@ libvarnish_la_SOURCES = \
 	vsha256.c \
 	vss.c
 
-libvarnish_la_CFLAGS = -DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"'
-libvarnish_la_LIBADD = ${RT_LIBS} ${NET_LIBS} ${LIBM} @PCRE_LIBS@
+libvarnish_la_CFLAGS = \
+	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+libvarnish_la_LIBADD = ${RT_LIBS} ${NET_LIBS} ${LIBM} @PCRE_LIBS@ \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 if ENABLE_TESTS
 TESTS = vnum_c_test

--- a/lib/libvarnishapi/Makefile.am
+++ b/lib/libvarnishapi/Makefile.am
@@ -44,9 +44,19 @@ libvarnishapi_la_SOURCES = \
 	libvarnishapi.map
 
 libvarnishapi_la_CFLAGS = \
-	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"'
+	-DVARNISH_STATE_DIR='"${VARNISH_STATE_DIR}"' \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
 
-libvarnishapi_la_LIBADD = @PCRE_LIBS@ @RT_LIBS@
+libvarnishapi_la_LIBADD = @PCRE_LIBS@ @RT_LIBS@ \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 if HAVE_LD_VERSION_SCRIPT
 libvarnishapi_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libvarnishapi.map

--- a/lib/libvarnishcompat/Makefile.am
+++ b/lib/libvarnishcompat/Makefile.am
@@ -8,7 +8,19 @@ AM_LDFLAGS  = $(AM_LT_LDFLAGS)
 
 pkglib_LTLIBRARIES = libvarnishcompat.la
 
-libvarnishcompat_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version
+libvarnishcompat_la_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
+libvarnishcompat_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 libvarnishcompat_la_SOURCES = \
 	daemon.c \

--- a/lib/libvcc/Makefile.am
+++ b/lib/libvcc/Makefile.am
@@ -8,7 +8,19 @@ AM_CPPFLAGS = \
 
 pkglib_LTLIBRARIES = libvcc.la
 
-libvcc_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version
+libvcc_la_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
+libvcc_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 libvcc_la_SOURCES = \
 	vcc_compile.h \

--- a/lib/libvgz/Makefile.am
+++ b/lib/libvgz/Makefile.am
@@ -3,8 +3,18 @@ AM_LDFLAGS  = $(AM_LT_LDFLAGS)
 
 pkglib_LTLIBRARIES = libvgz.la
 
-libvgz_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version
-libvgz_la_CFLAGS = -D_LARGEFILE64_SOURCE=1 -DZLIB_CONST $(libvgz_extra_cflags)
+libvgz_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
+libvgz_la_CFLAGS = -D_LARGEFILE64_SOURCE=1 -DZLIB_CONST $(libvgz_extra_cflags) \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
 
 libvgz_la_SOURCES = \
 	adler32.c \

--- a/lib/libvmod_debug/Makefile.am
+++ b/lib/libvmod_debug/Makefile.am
@@ -13,7 +13,19 @@ vmodtoolargs = --strict
 
 noinst_LTLIBRARIES = libvmod_debug.la
 
-libvmod_debug_la_LDFLAGS = $(AM_LDFLAGS) -module -export-dynamic -avoid-version -shared -rpath /nowhere
+libvmod_debug_la_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
+libvmod_debug_la_LDFLAGS = $(AM_LDFLAGS) -module -export-dynamic -avoid-version -shared -rpath /nowhere \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 libvmod_debug_la_SOURCES = \
 	vmod_debug.c \

--- a/lib/libvmod_directors/Makefile.am
+++ b/lib/libvmod_directors/Makefile.am
@@ -12,7 +12,19 @@ vmodtool = $(top_srcdir)/lib/libvcc/vmodtool.py
 vmodtoolargs = --strict
 vmod_LTLIBRARIES = libvmod_directors.la
 
-libvmod_directors_la_LDFLAGS = $(AM_LDFLAGS) -module -export-dynamic -avoid-version -shared
+libvmod_directors_la_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
+libvmod_directors_la_LDFLAGS = $(AM_LDFLAGS) -module -export-dynamic -avoid-version -shared \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 libvmod_directors_la_SOURCES = \
 	vdir.c \

--- a/lib/libvmod_std/Makefile.am
+++ b/lib/libvmod_std/Makefile.am
@@ -13,7 +13,19 @@ vmodtool = $(top_srcdir)/lib/libvcc/vmodtool.py
 vmodtoolargs = --strict
 vmod_LTLIBRARIES = libvmod_std.la
 
-libvmod_std_la_LDFLAGS = $(AM_LDFLAGS) -module -export-dynamic -avoid-version -shared
+libvmod_std_la_CFLAGS = \
+	@ASAN_CFLAGS@ \
+	@MSAN_CFLAGS@ \
+	@TSAN_CFLAGS@ \
+	@UBSAN_CFLAGS@ \
+	@COVERAGE_CFLAGS@
+
+libvmod_std_la_LDFLAGS = $(AM_LDFLAGS) -module -export-dynamic -avoid-version -shared \
+	@ASAN_LDFLAGS@ \
+	@MSAN_LDFLAGS@ \
+	@TSAN_LDFLAGS@ \
+	@UBSAN_LDFLAGS@ \
+	@COVERAGE_LDFLAGS@
 
 libvmod_std_la_SOURCES = \
 	vmod_std.c \


### PR DESCRIPTION
Modern versions of gcc and clang support various runtime sanitizers that
can be used to find nasty bugs at runtime. Including support for these
in the build is useful, but also it is useful to know how much code
coverage you're getting with tests when using these sanitizers.

This patch adds build-time support for the sanitizers as well as gcov
support to get code coverage metrics on varnish tests. To get HTML
output of this information, "lcov" is a useful tool. The general
workflow is:

        make
        lcov -o varnish_initial.info -i -c -d `pwd`
        make check
        lcov -o varnish_test.info -c -d `pwd`
        lcov -a varnish_initial.info -a varnish_test.info -o varnish_total.info

HTML output can then be generated using lcov's genhtml tool. This
information can then be evaluated to determine whether more tests are
needed to provide more test-time safety guarantees based on an initial
lack of warnings or errors from sanitizer tools.