### PR TITLE
Doc: note about port 80 setup for recent Debian/Ubuntu releases

### DIFF
--- a/doc/sphinx/tutorial/putting_varnish_on_port_80.rst
+++ b/doc/sphinx/tutorial/putting_varnish_on_port_80.rst
@@ -40,8 +40,6 @@ Create new file `/etc/systemd/system/varnish.service.d/customexec.conf`
   ExecStart=
   ExecStart=/usr/sbin/varnishd -a :80 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
 
-Reload systemctl (`systemctl daemon-reload`) before restarting Varnish.
-
 
 Red Hat Enterprise Linux / CentOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/tutorial/putting_varnish_on_port_80.rst
+++ b/doc/sphinx/tutorial/putting_varnish_on_port_80.rst
@@ -9,8 +9,8 @@ First we stop varnish: ``service varnish stop``
 
 Now we need to edit the configuration file that starts Varnish.
 
-Debian/Ubuntu
-~~~~~~~~~~~~~
+Debian/Ubuntu (old)
+~~~~~~~~~~~~~~~~~~~
 
 On Debian/Ubuntu this is `/etc/default/varnish`. In the file you'll find
 some text that looks like this::
@@ -29,9 +29,19 @@ Change it to::
                -S /etc/varnish/secret \
                -s malloc,256m"
 
-Since April 2015, Debian (v8) and Ubuntu (v15.04) are using systemd as 
-a default init system. You should edit `/lib/systemd/system/varnish.service` 
-file instead.
+Debian (v8+) / Ubuntu (v15.04+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since April 2015, Debian and Ubuntu are using systemd as a default init system. 
+
+Create new file `/etc/systemd/system/varnish.service.d/customexec.conf`
+
+  [Service]
+  ExecStart=
+  ExecStart=/usr/sbin/varnishd -a :80 -T localhost:6082 -f /etc/varnish/default.vcl -S /etc/varnish/secret -s malloc,256m
+
+Reload systemctl (`systemctl daemon-reload`) before restarting Varnish.
+
 
 Red Hat Enterprise Linux / CentOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/tutorial/putting_varnish_on_port_80.rst
+++ b/doc/sphinx/tutorial/putting_varnish_on_port_80.rst
@@ -29,6 +29,10 @@ Change it to::
                -S /etc/varnish/secret \
                -s malloc,256m"
 
+Since April 2015, Debian (v8) and Ubuntu (v15.04) are using systemd as 
+a default init system. You should edit `/lib/systemd/system/varnish.service` 
+file instead.
+
 Red Hat Enterprise Linux / CentOS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Unfortunately editing /etc/default/varnish does not work anymore.

Details: http://deshack.net/how-to-varnish-listen-port-80-systemd/
