### PR TITLE
[3.0] Enable streaming for ESI requests.

### DIFF
--- a/bin/varnishd/cache_center.c
+++ b/bin/varnishd/cache_center.c
@@ -750,7 +750,7 @@ cnt_fetchbody(struct sess *sp)
 	else if (sp->wrk->is_gzip)
 		sp->wrk->vfp = &vfp_testgzip;
 
-	if (sp->wrk->do_esi || sp->esi_level > 0)
+	if (sp->wrk->do_esi)
 		sp->wrk->do_stream = 0;
 	if (!sp->wantbody)
 		sp->wrk->do_stream = 0;


### PR DESCRIPTION
I noticed that Varnish does not support streaming of ESI requests. However the infrastructure is available to do so, so this simple patch fixes it for me.

Putting up a version for 3.0 branch as that is what I use in production right now.

Note: There are some edge-cases left, in which case ESI_DeliverChild is called:

``` c
        if (sp->wrk->res_mode & RES_ESI_CHILD && sp->wrk->gzip_resp) {
                ESI_DeliverChild(sp);
        } else if (sp->wrk->res_mode & RES_ESI_CHILD &&
            !sp->wrk->gzip_resp && sp->obj->gziped) {
                res_WriteGunzipObj(sp);
       }
```

Those cases should probably disable streaming instead of just looking at the esi_level.
